### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 __pycache__/
 .DS_Store
+.vscode/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This was a quick weekend project, but feel free to add new plugins or features. 
 ## Setup
 
 ### Suggested terminal emulator
-This package outputs directly to stdout. I recommend running this on a terminal with a scanline aesthetic, such as cool-retro-terminal.
+This package outputs directly to stdout. I recommend running this on a terminal with a scanline aesthetic, such as [cool-retro-term (Linux/Mac)](https://github.com/Swordfish90/cool-retro-term) or [windows-terminal-shaders (Windows)](https://github.com/Hammster/windows-terminal-shaders).
 
 I recommend using a rather large terminal font size to get the right look. The included ascii art assumes a minimum terminal width of 64 characters. That said, I wouldn't recommend going higher than 100.
 
@@ -28,7 +28,7 @@ This is all python, so installation is pretty straightforward.
 2) Until you get your look right, I recommend specifying ``debug=true`` in the config so that it doesn't access openAI while you're iterating on cool-retro-terminal settings/etc.
 3) Add the muthur script in the bin dir to your path or just run it directly. Run ``muthur --plugin cronus`` for the Cronus' onboard MU/TH/UR or ``muthur --plugin montero`` for the montero.
 
-To be honest, I haven't attempted to run this from another machine yet, so I might have missed some steps. Because I'm doing sound in a dumb way for now, it will be mac dependant unless you update play_sound() in terminal.py
+To be honest, I haven't attempted to run this from another machine yet, so I might have missed some steps.
 
 ### Config
 You can configure MU/TH/UR plugins for different acts and story points. For example, the Cronus plugin can be configured to acknowledge that the characters have already woken from cryo. Take a look at the config file to see what else is configurable.
@@ -63,7 +63,6 @@ While running the program, the user may use commands to interact with the tool. 
  - ``!save`` allows you to save the current status of the interaction. Use ``!save name`` to choose you name for the savefile
 
 ## Outstanding work (in vague order of priority)
-- Output sound in less dumb way.
 - Allow for user to quit MU/TH/UR from within MU/TH/UR using natural language.
 - Add a mode to allow it to print exact text as defined in a config or text document, rather than interacting with bot (user request)
 - Make prompts configurable with string replacements.

--- a/muthur_gpt/muthur_terminal.py
+++ b/muthur_gpt/muthur_terminal.py
@@ -2,9 +2,10 @@ import os
 import random
 import subprocess
 import re
+import sys
 import time
 from termcolor import colored
-
+from simpleaudio import WaveObject
 from muthur_gpt import constants
 
 class MuthurTerminal():
@@ -17,7 +18,10 @@ class MuthurTerminal():
         self.mute = mute
 
     def clear(self):
-        os.system("clear")
+        if sys.platform.startswith('win'):
+            os.system("cls")
+        else:
+            os.system("clear")
 
     def print_header(self, header_override=None):
         if header_override:
@@ -81,21 +85,19 @@ class MuthurTerminal():
     def print_slow(self, text, speed=None, sound=True):
         if not speed:
             speed = self.config.get(constants.CONFIG_KEY_DEFAULT_SPEED)
-        process = self.play_sound("typing_long")
+        play_object = self.play_sound("typing_long")
         for char in text:
             print(char, end="", flush=True)
             time.sleep(speed)
             if sound and not self.mute:
-                poll = process.poll()
-                if poll is not None:
-                    # Sound is over
-                    process = self.play_sound("subtle_long_type")
+                if not play_object.is_playing():
+                    play_object = self.play_sound("subtle_long_type")
                 elif char == "\n":
                     return_sound_name = "loud_type_start"
-                    process = self.play_sound(return_sound_name)
+                    play_object = self.play_sound(return_sound_name)
         self.print_space(1)
-        if process:
-            process.kill()
+        if play_object.is_playing():
+            play_object.stop()
 
     def print_reply(self, text):
         """
@@ -135,18 +137,17 @@ class MuthurTerminal():
     def print_slow_lines(self, text, speed=None, sound=True):
         if not speed:
             speed = self.config.get(constants.CONFIG_KEY_DEFAULT_SPEED)
-        process = self.play_sound("typing_long")
+        play_object = self.play_sound("typing_long")
         for line in text.split("\n"):
             print(line)
             time.sleep(speed)
             if sound and not self.mute:
-                poll = process.poll()
-                if poll is not None:
+                if not play_object.is_playing():
                     # Sound is over
-                    process = self.play_sound("subtle_long_type")
+                    play_object = self.play_sound("subtle_long_type")
         self.print_space(1)
-        if process:
-            process.kill()
+        if play_object.is_playing():
+            play_object.stop()
 
     def print_previous_input(self, user_input):
         self.print_space(constants.PREV_INPUT_TOP_MARGIN)
@@ -173,7 +174,7 @@ class MuthurTerminal():
             sound_path = self.path_resolver.get_sound_path(sound_name)
             if not sound_path:
                 raise Exception(f"Sound file unresolved for {sound_name}")
-            return subprocess.Popen(["afplay", sound_path])
+            return WaveObject.from_wave_file(sound_path).play()
 
     def display_image(self, image_name):
         """
@@ -182,7 +183,7 @@ class MuthurTerminal():
         self.play_sound("screen_display")
 
         try:
-            with open(self.path_resolver.get_ascii_path(image_name), "r") as f:
+            with open(self.path_resolver.get_ascii_path(image_name), "r", encoding="utf-8") as f:
                 ascii_image = f.read()
         except:
             # If image isn't readable or path doesn't exist

--- a/muthur_plugins/cronus/__init__.py
+++ b/muthur_plugins/cronus/__init__.py
@@ -24,10 +24,10 @@ class CronusPlugin(Plugin):
         super().__init__(
             CronusPlugin.NAME, config, terminal, path_resolver)
 
-        with open(self.path_resolver.get_ascii_path("WEYLAND_LOGO"), "r") as f:
+        with open(self.path_resolver.get_ascii_path("WEYLAND_LOGO"), "r", encoding="utf-8") as f:
             self.logo = f.read()
 
-        with open(self.path_resolver.get_ascii_path("BOOT_TEXT"), "r") as f:
+        with open(self.path_resolver.get_ascii_path("BOOT_TEXT"), "r", encoding="utf-8") as f:
             self.boot_text = f.read()
 
     def filter_bot_reply(self, bot_reply):

--- a/muthur_plugins/cronus_life_support/__init__.py
+++ b/muthur_plugins/cronus_life_support/__init__.py
@@ -30,10 +30,10 @@ class CronusLifeSupportPlugin(Plugin):
             CronusLifeSupportPlugin.NAME, config, terminal, path_resolver)
 
         self.life_support = LifeSupportTracker(config)
-        with open(self.path_resolver.get_ascii_path("WEYLAND_LOGO"), "r") as f:
+        with open(self.path_resolver.get_ascii_path("WEYLAND_LOGO"), "r", encoding="utf-8") as f:
             self.logo = f.read()
 
-        with open(self.path_resolver.get_ascii_path("BOOT_TEXT"), "r") as f:
+        with open(self.path_resolver.get_ascii_path("BOOT_TEXT"), "r", encoding="utf-8") as f:
             self.boot_text = f.read()
 
     def draw_secondary_header(self):

--- a/muthur_plugins/fort_nebraska/__init__.py
+++ b/muthur_plugins/fort_nebraska/__init__.py
@@ -22,9 +22,9 @@ class FortNebraskaPlugin(Plugin):
     def __init__(self, config, terminal, path_resolver):
         super().__init__(
             FortNebraskaPlugin.NAME, config, terminal, path_resolver)
-        with open(self.path_resolver.get_ascii_path("SEEGSON_LOGO"), "r") as f:
+        with open(self.path_resolver.get_ascii_path("SEEGSON_LOGO"), "r", encoding="utf-8") as f:
             self.logo = f.read()
-        with open(self.path_resolver.get_ascii_path("BOOT_TEXT"), "r") as f:
+        with open(self.path_resolver.get_ascii_path("BOOT_TEXT"), "r", encoding="utf-8") as f:
             self.boot_text = f.read()
 
     def filter_plugin_prompt(self, prompt):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+termcolor
+simpleaudio-patched


### PR DESCRIPTION
Got this working for me on 2 different Windows devices with 2 different versions of python. My manual testing got as far as displaying the Cronus decks and everything was working as expected.

- Use either `cls` or `clear` depending on platform.
- Explicitly specify utf-8 encoding for reading the art files. I guess Windows defaults to ascii. Despite the directories/variables being named "ascii" they actually contain unicode characters.
- Output sound in a "less dumb way" 😄. I actually think afplay is a pretty elegant solution for a Mac-only application. My new implementation using simpleaudio follows the same pattern.
- Add requirements.txt to make setup simpler.
- Add vscode project files to gitignore
- Update README to reflect new audio and platform support, as well as links to suggested retro terminals.